### PR TITLE
Remove nested breakpoint in fullscreen-mode CSS

### DIFF
--- a/packages/interface/src/components/fullscreen-mode/style.scss
+++ b/packages/interface/src/components/fullscreen-mode/style.scss
@@ -3,12 +3,8 @@ body.js.is-fullscreen-mode {
 	@include break-medium {
 		// Reset the html.wp-topbar padding.
 		// Because this uses negative margins, we have to compensate for the height.
-		margin-top: -$admin-bar-height-big;
-		height: calc(100% + #{ $admin-bar-height-big });
-		@include break-medium() {
-			margin-top: -$admin-bar-height;
-			height: calc(100% + #{ $admin-bar-height });
-		}
+		margin-top: -$admin-bar-height;
+		height: calc(100% + #{ $admin-bar-height });
 
 		#adminmenumain,
 		#wpadminbar {


### PR DESCRIPTION
With a `break-medium` mixin nested inside a previous `break-medium`, the stylesheet compiles with extra media queries and an unused value of 46px. So the stylesheet in WordPress 5.4 has this:

```
@media (min-width:782px){body.js.is-fullscreen-mode{margin-top:-46px;height:calc(100% + 46px)}}@media (min-width:782px) and (min-width:782px){body.js.is-fullscreen-mode{margin-top:-32px;height:calc(100% + 32px)}}@media (min-width:782px){
```

## Description
Pull request https://github.com/WordPress/gutenberg/pull/13425 overrode the `$admin-bar-height-big` values originally used for narrower screen sizes. Since those are no longer used, this removes those styles and the redundant media queries.

## Testing
This still ought to be tested. Thanks!