### PR TITLE
Restore `html` scope in reset.scss selectors

### DIFF
--- a/packages/block-library/src/reset.scss
+++ b/packages/block-library/src/reset.scss
@@ -7,7 +7,7 @@
 
 // We use :where to keep specificity minimal.
 // https://css-tricks.com/almanac/selectors/w/where/
-:where(.editor-styles-wrapper) {
+html :where(.editor-styles-wrapper) {
 	/**
 	* The following styles revert to the browser defaults overriding the WPAdmin styles.
 	* This is only needed while the block editor is not being loaded in an iframe.


### PR DESCRIPTION
Fixes #57176

(simplest option)

## What?
Raise the specificity of reset selectors to what they were before [#46752](https://github.com/WordPress/gutenberg/pull/46752) so that the CSS reset overrides styles in [wp-admin/css/common.css](https://github.com/WordPress/wordpress-develop/blob/96de28cc29774aeb4577b0d314e6b1724c1804ae/src/wp-admin/css/common.css#L223-L230).

## Why?
The admin CSS bleed affects the iframed post editor in 'classic' themes that do not specify `font-size`, `line-height` and/or `background-color` for the `body`. In addition to the extra discrepancies between editor and front end, the smaller text is more difficult to read when editing post content, and the background reduces color contrast.

## How?
Revert the `reset.scss` change from [#46752](https://github.com/WordPress/gutenberg/pull/46752).

## Testing Instructions
1. Activate a 'classic' theme such as Twenty Thirteen or Twenty Fourteen (those two currently have the wrong font size and background color).
2. Create a new post and add blocks including a Paragraph and/or List.
3. Check whether the post editor is using an iframe by using the [browser inspector](https://blog.hubspot.com/website/how-to-inspect) on text in a Paragraph block. If it is **not** inside an iframe, you may need to save the post and then deactivate plugins or go to Preferences and remove a panel such as Custom Fields.
4. In the browser inspector, look for styles on the `body` element coming from `common.css` (or `load-styles.php` if `SCRIPT_DEBUG` is `false`). With the PR applied, the `background`, `color`, `font-family`, `font-size` and `line-height` properties should have a line through them (the `min-width` is not reset, but that seems to be fine).
![admin body styles crossed out, except for min-width](https://github.com/sabernhardt/gutenberg/assets/17100257/c9aa56fe-d1a2-4989-8436-4edf84b82d48)