### PR TITLE
iframe: Add `lang` attributes and `rtl` class when available

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -157,11 +157,18 @@ function Iframe( {
 					( name ) =>
 						name.startsWith( 'admin-color-' ) ||
 						name.startsWith( 'post-type-' ) ||
-						name === 'wp-embed-responsive'
+						name === 'wp-embed-responsive' ||
+						name === 'rtl'
 				)
 			);
 
-			contentDocument.dir = ownerDocument.dir;
+			if ( ownerDocument.documentElement.lang ) {
+				contentDocument.documentElement.lang = ownerDocument.documentElement.lang;
+			}
+
+			if ( ownerDocument.dir ) {
+				contentDocument.dir = ownerDocument.dir;
+			}
 
 			for ( const compatStyle of getCompatibilityStyles() ) {
 				if ( contentDocument.getElementById( compatStyle.id ) ) {


### PR DESCRIPTION
## What?
Copies `lang` and `dir` attributes from the editor screen's `html` element and the `rtl` admin body class within the `iframe`, when they are available.

## Why?
Themes have special styles with the `.rtl` class and/or with certain languages (for example, using a system font for non-latin characters).

## Testing Instructions
